### PR TITLE
Do not allow script tags unless `allow scripts` property is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ When `render()` is invoked, Our `<Sidebar />` component is substituted for the `
 
 Subsequent `render()`s diff against that DOM just like a normal JSX rendering flow would.
 
+### Optional properties
+
+**allow-scripts** - By default, preact-markup sanitizes the rendered HTML by removing script tags unless the `allow-scripts` property is defined. For example,
+
+```
+let markup = `<em>hello!</em><h1>asdflkj</h1><script type="text/javascript">alert("Hello world");</script>`;
+render(<Markup markup={markup}  allow-scripts />, document.body);
+```
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,9 @@ export default class Markup extends Component {
 
 		this.setComponents(components);
 
+		let options = {'allow-scripts': this.props['allow-scripts']};
 		try {
-			vdom = markupToVdom(markup, type, h, this.map);
+			vdom = markupToVdom(markup, type, h, this.map, options);
 		} catch(error) {
 			if (onError) onError({ error });
 		}

--- a/src/markup-to-vdom.js
+++ b/src/markup-to-vdom.js
@@ -9,7 +9,7 @@ const EMPTY_OBJ = {};
 *	@param {Function} reviver	The JSX/hyperscript reviver (`h` function) to use. For example, Preact's `h` or `ReactDOM.createElement`.
 *	@param {Object} [map]		Optional map of custom element names to Components or variant element names.
  */
-export default function markupToVdom(markup, type, reviver, map) {
+export default function markupToVdom(markup, type, reviver, map, options) {
 	let dom = parseMarkup(markup, type);
 
 	if (dom && dom.error) {
@@ -18,7 +18,7 @@ export default function markupToVdom(markup, type, reviver, map) {
 
 	let body = dom && dom.body || dom;
 	visitor.map = map || EMPTY_OBJ;
-	let vdom = body && toVdom(body, visitor, reviver);
+	let vdom = body && toVdom(body, visitor, reviver, options);
 	visitor.map = null;
 
 

--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -1,13 +1,18 @@
 // deeply convert an XML DOM to VDOM
-export default function toVdom(node, visitor, h) {
+export default function toVdom(node, visitor, h, options) {
 	walk.visitor = visitor;
 	walk.h = h;
+	walk.options = options || {};
 	return walk(node);
 }
 
 function walk(n) {
 	if (n.nodeType===3) return 'textContent' in n ? n.textContent : n.nodeValue;
 	if (n.nodeType!==1) return null;
+	// Do not allow script tags unless explicitly specified
+	if (String(n.nodeName).toLowerCase() === "script" && !walk.options['allow-scripts']){
+		return null;
+	}
 	let out = walk.h(
 		String(n.nodeName).toLowerCase(),
 		getProps(n.attributes),

--- a/test/index.js
+++ b/test/index.js
@@ -131,4 +131,15 @@ describe('Markup', () => {
 			</div>
 		);
 	});
+
+	it('ignore script tags unless allow-scripts is enabled', () => {
+		window.stub = sinon.stub();
+		let markup = `<em>hello!</em><h1>asdflkj</h1><script type="text/javascript">window.stub();</script>`;
+		render(<Markup markup={markup} />, scratch);
+		expect(window.stub.called,"stub should NOT be triggered if allow-scripts is not explicitly enabled").to.equal(false);
+		render(<Markup markup={markup} allow-scripts/>, scratch);
+		expect(window.stub.called,"stub should be triggered if allow-scripts is enabled").to.equal(true);
+		delete window.stub;
+
+	});
 });


### PR DESCRIPTION
This is the first PR resulting from our discussion at developit/preact#95 

Once merged, this PR will be followed by another one that allows events to be parsed from string attributes. 