### PR TITLE
fixed camelCased props mapping from HTML

### DIFF
--- a/src/markup-to-vdom.js
+++ b/src/markup-to-vdom.js
@@ -25,8 +25,21 @@ export default function markupToVdom(markup, type, reviver, map, options) {
 	return vdom && vdom.children || null;
 }
 
+function toCamelCase(name) {
+	return name.replace(/-(.)/g, (match, letter) =>letter.toUpperCase())
+}
+
 function visitor(node) {
 	let name = node.nodeName.toLowerCase(),
 		map = visitor.map;
-	node.nodeName = map && map.hasOwnProperty(name) ? map[name] : name.replace(/[^a-z0-9-]/i,'');
+	if (map && map.hasOwnProperty(name)){
+		node.nodeName = map[name];
+		node.attributes = Object.keys(node.attributes).reduce((attrs,attrName)=>{
+			attrs[toCamelCase(attrName)] = node.attributes[attrName];
+			return attrs;
+		},{})
+	} else {
+		node.nodeName =  name.replace(/[^a-z0-9-]/i,'');
+	}
+
 }

--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -26,6 +26,10 @@ function walk(n) {
 	return out;
 }
 
+function toCamelCase(name) {
+	return name.replace(/-(.)/g, (match, letter) =>letter.toUpperCase())
+}
+
 function getProps(attrs) {
 	let len = attrs && attrs.length;
 	if (!len) return null;
@@ -36,7 +40,7 @@ function getProps(attrs) {
 		if (name.substring(0,2)==='on' && walk.options.allowEvents){
 			value  = new Function(value); // eslint-disable-line no-new-func
 		}
-		props[name] = value;
+		props[toCamelCase(name)] = value;
 	}
 	return props;
 }

--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -26,10 +26,6 @@ function walk(n) {
 	return out;
 }
 
-function toCamelCase(name) {
-	return name.replace(/-(.)/g, (match, letter) =>letter.toUpperCase())
-}
-
 function getProps(attrs) {
 	let len = attrs && attrs.length;
 	if (!len) return null;
@@ -40,7 +36,7 @@ function getProps(attrs) {
 		if (name.substring(0,2)==='on' && walk.options.allowEvents){
 			value  = new Function(value); // eslint-disable-line no-new-func
 		}
-		props[toCamelCase(name)] = value;
+		props[name] = value;
 	}
 	return props;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -86,13 +86,14 @@ describe('Markup', () => {
 	});
 
 	it('should render mapped components from XML', () => {
-		const Foo = ({ a, b, children }) => (<div class="foo" data-a={a} data-b={b}>{ children }</div>);
+		const Foo = ({ a, b, camelCasedProperty, children }) =>
+			(<div class="foo" camelCasedProperty={camelCasedProperty} data-a={a} data-b={b}>{ children }</div>);
 
 		expect(
-			<Markup markup='<foo a="1" b="two" />' components={{ Foo }} />
+			<Markup markup='<foo a="1" b="two" camel-cased-property="2" />' components={{ Foo }} />
 		).to.eql(
 			<div class="markup">
-				<div class="foo" data-a="1" data-b="two" />
+				<div class="foo" data-a="1" data-b="two" camelCasedProperty="2"/>
 			</div>
 		);
 
@@ -110,13 +111,14 @@ describe('Markup', () => {
 	});
 
 	it('should render mapped components from HTML', () => {
-		const XFoo = ({ p, children }) => (<div class="x-foo" asdf={p}>hello { children }</div>);
+		const XFoo = ({ p, camelCasedProperty, children }) =>
+			(<div class="x-foo" camelCasedProperty={camelCasedProperty} asdf={p}>hello { children }</div>);
 
 		expect(
-			<Markup type="html" markup='<x-foo p="1" />' components={{ XFoo }} />
+			<Markup type="html" markup='<x-foo p="1" camel-cased-property="2"/>' components={{ XFoo }} />
 		).to.eql(
 			<div class="markup">
-				<div class="x-foo" asdf="1">hello </div>
+				<div class="x-foo" asdf="1" camelCasedProperty="2">hello </div>
 			</div>
 		);
 

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,49 @@ describe('Markup', () => {
 		);
 	});
 
+	it('should correctly map XML properties', () => {
+		const Foo = ({camelCasedProperty, children}) =>
+			(<div class="foo" camelCasedProperty={camelCasedProperty}>{ children }</div>);
+
+		expect(
+			<Markup markup='<foo camelCasedProperty="2" />' components={{ Foo }}/>
+		).to.eql(
+			<div class="markup">
+				<div class="foo" camelCasedProperty="2"/>
+			</div>
+		);
+		expect(
+			<Markup markup='<foo camel-cased-property="2" />' components={{ Foo }}/>
+		).to.eql(
+			<div class="markup">
+				<div class="foo" camelCasedProperty="2"/>
+			</div>
+		);
+	});
+
+	it('should correctly map HTML properties', () => {
+		const Foo = ({camelCasedProperty, children}) =>
+			(<div class="foo" camelCasedProperty={camelCasedProperty}>{ children }</div>);
+
+		//Notice that camelCasedProperty is gone in the output cause it's mapped in `prop.camelcasedproperty`
+		// and Foo isn't aware of it
+		expect(
+			<Markup type="html" markup='<foo camelCasedProperty="2" />' components={{ Foo }}/>
+		).to.eql(
+			<div class="markup">
+				<div class="foo"/>
+			</div>
+		);
+
+		expect(
+			<Markup type="html" markup='<foo camel-cased-property="2" />' components={{ Foo }}/>
+		).to.eql(
+			<div class="markup">
+				<div class="foo" camelCasedProperty="2"/>
+			</div>
+		);
+	});
+
 	it('should render mapped components from HTML', () => {
 		const XFoo = ({ p, camelCasedProperty, children }) =>
 			(<div class="x-foo" camelCasedProperty={camelCasedProperty} asdf={p}>hello { children }</div>);

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,16 @@ describe('Markup', () => {
 				<div class="foo" camelCasedProperty="2"/>
 			</div>
 		);
+
+		expect(
+			<Markup markup='<foo camel-cased-property="2"><div data-foo="foo"></div></foo>' components={{ Foo }}/>
+		).to.eql(
+			<div class="markup">
+				<div class="foo" camelCasedProperty="2">
+					<div data-foo="foo"></div>
+				</div>
+			</div>
+		);
 	});
 
 	it('should correctly map HTML properties', () => {
@@ -151,6 +161,17 @@ describe('Markup', () => {
 				<div class="foo" camelCasedProperty="2"/>
 			</div>
 		);
+
+		expect(
+			<Markup type="html" markup='<foo camel-cased-property="2"><div data-foo="foo"></div></foo>' components={{ Foo }}/>
+		).to.eql(
+			<div class="markup">
+				<div class="foo" camelCasedProperty="2">
+					<div data-foo="foo"></div>
+					</div>
+			</div>
+		);
+
 	});
 
 	it('should render mapped components from HTML', () => {


### PR DESCRIPTION
Hi,
I've come across one bug when preact-markup was used in 'html' mode it didn't correctly map HTMLNode properties back to preact props.
Cause attributes in HTML are lowercased, but in XML they are left as is.
I suggest to use dashed names in attributes for html and convert them back to camelCase.
