### PR TITLE
[WIP] Made component compatible with React.createElement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ export default class Markup extends Component {
 		}
 	}
 
-	render({ wrap=true, type, markup, components, reviver, onError, 'allow-scripts':allowScripts, 'allow-events':allowEvents, trim, ...props }) {
+	render() {
+		let { wrap=true, type, markup, components, reviver, onError, 'allow-scripts':allowScripts, 'allow-events':allowEvents, trim, ...props } = this.props;
 		let h = reviver || this.reviver || this.constructor.prototype.reviver || customReviver || defaultReviver,
 			vdom;
 

--- a/src/markup-to-vdom.js
+++ b/src/markup-to-vdom.js
@@ -21,8 +21,8 @@ export default function markupToVdom(markup, type, reviver, map, options) {
 	let vdom = body && toVdom(body, visitor, reviver, options);
 	visitor.map = null;
 
-
-	return vdom && vdom.children || null;
+	// Return VDOM children for reviver (Preact uses children where React uses props.children).
+	return vdom && (vdom.children || vdom.props.children) || null;
 }
 
 function toCamelCase(name) {


### PR DESCRIPTION
This PR is an attempt to make the component compatible with React. There is still an issue in the `visitor()` function where it uses `nodeName` (Preact read/write) instead of `type` (React read-only).