### PR TITLE
Handle case where document is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint {src,test}",
     "test:karma": "karma start --single-run",
     "prepublish": "npm-run-all build test",
+    "prepare": "npm run -s build",
     "release": "npm run -s build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,10 @@ export default class Markup extends Component {
 			trim
 		};
 
+		if (typeof document === 'undefined') {
+			return h('div', Object.assign({ dangerouslySetInnerHTML: { __html: markup } }, props), null);
+		}
+
 		try {
 			vdom = markupToVdom(markup, type, h, this.map, options);
 		} catch (error) {


### PR DESCRIPTION
When using this library with preact-cli we get build error when prerendering because it expects `document` to not be undefined. The fallback here is to use dangerouslySetInnerHTML with the supplied markup.