### PR TITLE
Added feature componentDefaultProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default class Markup extends Component {
 		}
 	}
 
-	render({ wrap=true, type, markup, components, reviver, onError, 'allow-scripts':allowScripts, 'allow-events':allowEvents, trim, ...props }) {
+	render({ wrap=true, type, markup, components, reviver, onError, 'allow-scripts':allowScripts, 'allow-events':allowEvents, trim, componentDefaultProps, ...props }) {
 		let h = reviver || this.reviver || this.constructor.prototype.reviver || customReviver || defaultReviver,
 			vdom;
 
@@ -35,7 +35,8 @@ export default class Markup extends Component {
 		let options = {
 			allowScripts,
 			allowEvents,
-			trim
+			trim,
+			componentDefaultProps
 		};
 
 		try {

--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -37,7 +37,10 @@ function walk(n, index, arr) {
 	// Do not allow script tags unless explicitly specified
 	if (nodeName==='script' && !walk.options.allowScripts) return null;
 
-	let props = Object.assign({}, walk.options.componentDefaultProps || {}, getProps(n.attributes));
+	let props = Object.keys(walk.visitor.map).indexOf(nodeName) !== -1
+		? Object.assign({}, walk.options.componentDefaultProps || {}, getProps(n.attributes))
+		: getProps(n.attributes);
+
 	let out = walk.h(
 		nodeName,
 		props,

--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -37,9 +37,10 @@ function walk(n, index, arr) {
 	// Do not allow script tags unless explicitly specified
 	if (nodeName==='script' && !walk.options.allowScripts) return null;
 
+	let props = Object.assign({}, walk.options.componentDefaultProps || {}, getProps(n.attributes));
 	let out = walk.h(
 		nodeName,
-		getProps(n.attributes),
+		props,
 		walkChildren(n.childNodes)
 	);
 	if (walk.visitor) walk.visitor(out);

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,19 @@ describe('Markup', () => {
 		);
 	});
 
+	it('should render mapped components from XML with componentDefaultProps', () => {
+		const Foo = ({ a, b, camelCasedProperty, someDefaultProp, anotherDefaultProp, children }) =>
+			(<div class="foo" camelCasedProperty={camelCasedProperty} data-a={a} data-b={b} data-some-default-prop={someDefaultProp} data-another-default-prop={anotherDefaultProp} >{ children }</div>);
+
+		expect(
+			<Markup markup='<foo a="1" b="two" camel-cased-property="2" />' components={{ Foo }} componentDefaultProps={ { someDefaultProp: 'foo', anotherDefaultProp: 'bar' } } />
+		).to.eql(
+			<div class="markup">
+				<div class="foo" data-a="1" data-b="two" camelCasedProperty="2" data-some-default-prop="foo" data-another-default-prop="bar" />
+			</div>
+		);
+	});
+
 	it('should correctly map XML properties', () => {
 		const Foo = ({camelCasedProperty, children}) =>
 			(<div class="foo" camelCasedProperty={camelCasedProperty}>{ children }</div>);


### PR DESCRIPTION
This feature for when the user wants to give all components rendered by
Markup to have some props by default.

I ran into the need for this feature when building a static blog that has some values I want to pass to some of the rendered components inside of the markup.

It's implemented by adding an additional prop to `<Markup />` called `componentDefaultProps` (name up for discussion, can change into whatever). This is then passed to the the options until being finally being passed to `to-vdom.js` where the props for each Component are set to `getProps(n.attributes)`. I changed this to a `let` called `props` that's the result of `Object.assign`'ing the `getProps(n.attributes)` and the supplied prop (`componentDefaultProps`).

I'll be more then happy to answer any questions may the need arise.

Thanks for reading my pull request! Let me know if there's anything I can do to make this easier for you guys :smile: 