### PR TITLE
Possible bug fix: nodeName is deprecated in Preact 10

### DIFF
--- a/src/parse-markup.js
+++ b/src/parse-markup.js
@@ -44,7 +44,7 @@ export default function parseMarkup(markup, type) {
 	}
 
 	// pluck out parser errors
-	if (fc && String(fc.nodeName).toLowerCase()==='parsererror') {
+	if (fc && String(fc.type).toLowerCase()==='parsererror') {
 		// remove post/preamble to get just the error message as text
 		fc.removeChild(fc.firstChild);
 		fc.removeChild(fc.lastChild);

--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -32,7 +32,7 @@ function walk(n, index, arr) {
 		return text;
 	}
 	if (n.nodeType!==1) return null;
-	let nodeName = String(n.nodeName).toLowerCase();
+	let nodeName = String(n.type).toLowerCase();
 
 	// Do not allow script tags unless explicitly specified
 	if (nodeName==='script' && !walk.options.allowScripts) return null;


### PR DESCRIPTION
However, I’m not sure if my proposed fix is correct. `console.log` gave me this error: `preact-markup: Error: getting vnode.nodeName is deprecated, use vnode.type`