### PR TITLE
Use preact Fragment to render multiple children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { h as defaultReviver, Component } from 'preact';
+import { h as defaultReviver, Component, Fragment } from 'preact';
 import markupToVdom from './markup-to-vdom';
 
 let customReviver;
@@ -49,7 +49,7 @@ export default class Markup extends Component {
 			}
 		}
 
-		if (wrap===false) return vdom && vdom[0] || null;
+		if (wrap===false) return vdom && h(Fragment, {}, vdom) || null;
 
 		// eslint-disable-next-line no-prototype-builtins
 		let c = props.hasOwnProperty('className') ? 'className' : 'class',

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { h as defaultReviver, Component, Fragment } from 'preact';
+import { h as defaultReviver, Component } from 'preact';
 import markupToVdom from './markup-to-vdom';
 
 let customReviver;
@@ -49,7 +49,7 @@ export default class Markup extends Component {
 			}
 		}
 
-		if (wrap===false) return vdom && h(Fragment, {}, vdom) || null;
+		if (wrap===false) return vdom || null;
 
 		// eslint-disable-next-line no-prototype-builtins
 		let c = props.hasOwnProperty('className') ? 'className' : 'class',


### PR DESCRIPTION
When `wrap = true`, `preact-markup` only renders the first child. Using Fragments, `preact-markup` can render all the children without wrapping them with a `<div />`.