### PR TITLE
Add 'as' and 'markupClass' Props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default class Markup extends Component {
 		}
 	}
 
-	render({ wrap=true, type, markup, components, reviver, onError, 'allow-scripts':allowScripts, 'allow-events':allowEvents, trim, ...props }) {
+	render({ as = 'div', markupClass = 'markup', wrap=true, type, markup, components, reviver, onError, 'allow-scripts':allowScripts, 'allow-events':allowEvents, trim, ...props }) {
 		let h = reviver || this.reviver || this.constructor.prototype.reviver || customReviver || defaultReviver,
 			vdom;
 
@@ -54,11 +54,13 @@ export default class Markup extends Component {
 		// eslint-disable-next-line no-prototype-builtins
 		let c = props.hasOwnProperty('className') ? 'className' : 'class',
 			cl = props[c];
-		if (!cl) props[c] = 'markup';
-		else if (cl.splice) cl.splice(0, 0, 'markup');
-		else if (typeof cl==='string') props[c] += ' markup';
-		else if (typeof cl==='object') cl.markup = true;
+		if (markupClass) {
+			if (!cl) props[c] = markupClass;
+			else if (cl.splice) cl.splice(0, 0, markupClass);
+			else if (typeof cl==='string') props[c] += ` ${markupClass}`;
+			else if (typeof cl==='object') cl.markup = true;
+		}
 
-		return h('div', props, vdom || null);
+		return h(as, props, vdom || null);
 	}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,43 @@ describe('Markup', () => {
 		expect(scratch.firstChild.innerHTML).to.equal(markup);
 	});
 
+	it('should render markup inside of a given component', () => {
+		expect(
+			<Markup as="span" markup={`<em>hello!</em>`} />
+		).to.eql(
+			<span class="markup">
+				<em>hello!</em>
+			</span>
+		);
+
+		const Component = props => <span {...props} />;
+		expect(
+			<Markup as={Component} markup={`<em>hello!</em>`} />
+		).to.eql(
+			<span class="markup">
+				<em>hello!</em>
+			</span>
+		);
+	});
+
+	it('should optionally render with a different className', () => {
+		expect(
+			<Markup markupClass="md" markup={`<em>hello!</em>`} />
+		).to.eql(
+			<div class="md">
+				<em>hello!</em>
+			</div>
+		);
+
+		expect(
+			<Markup markupClass={false} markup={`<em>hello!</em>`} />
+		).to.eql(
+			<div>
+				<em>hello!</em>
+			</div>
+		);
+	});
+
 	it('should render xml', () => {
 		render(<Markup markup="<div><x-foo /></div>" />, scratch);
 		expect(scratch.firstChild.innerHTML).to.equal('<div><x-foo></x-foo></div>');


### PR DESCRIPTION
Added two new props to provide better control over the rendered wrapper element.

`as` (default: 'div') will accept a component or a string to set the wrapping element

`markdownClass` (default: 'markdown') will accept a string which will be added to the classNames list on the wrapping element. A falsy value will result in no class name being added.

For myself this solves a use-case where I wanted the wrapper element to be a list item instead of a div and I didn't want to add a class name either. This should allow better compatibility with `styled-components` as well, allowing users of that library to change the rendered element using the `forwardedAs` prop from that library.