### PR TITLE
Support Preact ≥10.3.2

### DIFF
--- a/src/to-vdom.js
+++ b/src/to-vdom.js
@@ -32,7 +32,7 @@ function walk(n, index, arr) {
 		return text;
 	}
 	if (n.nodeType!==1) return null;
-	let nodeName = String(n.nodeName).toLowerCase();
+	let nodeName = String(n.nodeName || n.type).toLowerCase();
 
 	// Do not allow script tags unless explicitly specified
 	if (nodeName==='script' && !walk.options.allowScripts) return null;


### PR DESCRIPTION
I simply added a fallback to `n.type` when querying Preact's `n.nodeName`.

I'm not sure about the depreciation time of `vnode.nodeName` or other changes that came with more recent versions but I do know this allowed me to use `preact-markup` just fine.